### PR TITLE
Bumps tj-actions/changed-files from 29.0.3 to 45.0.8

### DIFF
--- a/.github/workflows/usage-changed.yaml
+++ b/.github/workflows/usage-changed.yaml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - id: changed-files
-        uses: tj-actions/changed-files@v29.0.3
+        uses: tj-actions/changed-files@v45.0.8
       - uses: ./
         with:
           ignore-default: 'true'

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 An [Action](https://docs.github.com/en/actions) that checks if files are covered by the [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) file.
 
+Forked because the upstream repo hasn't been updated in a couple years.
+
 ## Usage
 Create a workflow (eg: `.github/workflows/seat-count.yml`). See [Creating a Workflow file](https://help.github.com/en/articles/configuring-a-workflow#creating-a-workflow-file).
 
@@ -27,7 +29,7 @@ jobs:
     name: Run Action
     runs-on: ubuntu-latest
     steps:
-      - uses: austenstone/codeowners-coverage@main
+      - uses: sibipro/codeowners-coverage@v1
 ```
 
 #### Example changed files in PR
@@ -46,7 +48,7 @@ jobs:
       - uses: actions/checkout@v3
       - id: changed-files
         uses: tj-actions/changed-files@v29.0.3
-      - uses: austenstone/codeowners-coverage@main
+      - uses: sibipro/codeowners-coverage@v1
         with:
           ignore-default: 'true'
           files: ${{ steps.changed-files.outputs.all_changed_files }}
@@ -58,8 +60,8 @@ Various inputs are defined in [`action.yml`](action.yml):
 | Name | Description | Default |
 | --- | - | - |
 | github&#x2011;token | Token to use to authorize. | ${{&nbsp;github.token&nbsp;}} |
-| include-gitignore | Weither to filter our files in .gitignore | true |
-| ignore-default | Weither to ignore the default rule `*` in CODEOWNERS file | false |
+| include-gitignore | Whether to filter our files in .gitignore | true |
+| ignore-default | Whether to ignore the default rule `*` in CODEOWNERS file | false |
 | files          | Filter check to only specific files | N/A
 <!-- 
 ## ⬅️ Outputs

--- a/action.yml
+++ b/action.yml
@@ -12,16 +12,24 @@ inputs:
     required: false
   include-gitignore:
     description: Whether to include files in .gitignore
-    default: 'true'
+    default: "true"
+    required: false
+  include-git:
+    description: Whether to include files in the .git directory
+    default: "false"
     required: false
   ignore-default:
     description: Whether to ignore the default `*` files
-    default: 'false'
+    default: "false"
     required: false
   files:
     description: The files to check
     required: false
+  parse-unowned-files:
+    description: Interpret lines starting with '#?' as unowned files that do not need to be covered
+    default: "true"
+    required: false
 
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"

--- a/dist/index.js
+++ b/dist/index.js
@@ -12008,20 +12008,33 @@ const fs_1 = __nccwpck_require__(7147);
 function getInputs() {
     const result = {};
     result.token = core.getInput("github-token");
-    result["include-gitignore"] = core.getBooleanInput("include-gitignore");
-    result["ignore-default"] = core.getBooleanInput("ignore-default");
+    result.includeGitignore = core.getBooleanInput("include-gitignore");
+    result.includeGit = core.getBooleanInput("include-git");
+    result.ignoreDefault = core.getBooleanInput("ignore-default");
+    result.parseUnownedFiles = core.getBooleanInput("parse-unowned-files");
     result.files = core.getInput("files");
     return result;
 }
 exports.getInputs = getInputs;
 const runAction = (_octokit, input) => __awaiter(void 0, void 0, void 0, function* () {
+    const addIgnoresToPatterns = (patterns) => {
+        let result = patterns;
+        if (!input.includeGit) {
+            result += "\n!.git";
+        }
+        return result;
+    };
     let allFiles = [];
     if (input.files) {
         allFiles = input.files.split(" ");
-        allFiles = yield (yield glob.create(allFiles.join("\n"))).glob();
+        allFiles = yield (yield glob.create(addIgnoresToPatterns(allFiles.join("\n")), {
+            matchDirectories: false,
+        })).glob();
     }
     else {
-        allFiles = yield (yield glob.create("*")).glob();
+        allFiles = yield (yield glob.create(addIgnoresToPatterns("*"), {
+            matchDirectories: false,
+        })).glob();
     }
     core.startGroup(`All Files: ${allFiles.length}`);
     core.info(JSON.stringify(allFiles));
@@ -12044,12 +12057,20 @@ const runAction = (_octokit, input) => __awaiter(void 0, void 0, void 0, functio
     let codeownersBufferFiles = codeownersBuffer
         .split("\n")
         .map((line) => line.split(" ")[0]);
-    codeownersBufferFiles = codeownersBufferFiles.filter((file) => !file.startsWith("#"));
     codeownersBufferFiles = codeownersBufferFiles.map((file) => file.replace(/^\//, ""));
-    if (input["ignore-default"] === true) {
+    codeownersBufferFiles = codeownersBufferFiles.filter((file) => !file.startsWith("#"));
+    if (input.ignoreDefault === true) {
         codeownersBufferFiles = codeownersBufferFiles.filter((file) => file !== "*");
     }
-    const codeownersGlob = yield glob.create(codeownersBufferFiles.join("\n"));
+    const unownedFilesPatterns = input.parseUnownedFiles
+        ? codeownersBuffer
+            .split("\n")
+            .filter((file) => file.startsWith("#?"))
+            .map((file) => file.replace(/^#\?\s*/, ""))
+        : [];
+    const codeownersGlob = yield glob.create(codeownersBufferFiles.join("\n"), {
+        matchDirectories: false,
+    });
     let codeownersFiles = yield codeownersGlob.glob();
     core.startGroup(`CODEOWNERS Files: ${codeownersFiles.length}`);
     core.info(JSON.stringify(codeownersFiles));
@@ -12062,18 +12083,31 @@ const runAction = (_octokit, input) => __awaiter(void 0, void 0, void 0, functio
     let gitIgnoreFiles = [];
     try {
         const gitIgnoreBuffer = (0, fs_1.readFileSync)(".gitignore", "utf8");
-        const gitIgnoreGlob = yield glob.create(gitIgnoreBuffer);
+        const gitIgnoreGlob = yield glob.create(gitIgnoreBuffer, {
+            matchDirectories: false,
+        });
         gitIgnoreFiles = yield gitIgnoreGlob.glob();
         core.info(`.gitignore Files: ${gitIgnoreFiles.length}`);
     }
     catch (error) {
         core.info("No .gitignore file found");
     }
+    const unownedFilesGlob = yield glob.create(unownedFilesPatterns.join("\n"), {
+        matchDirectories: false,
+    });
+    const unownedFiles = yield unownedFilesGlob.glob();
+    if (input.parseUnownedFiles) {
+        core.info(`Unowned Files: ${unownedFiles.length}`);
+    }
     let filesCovered = codeownersFiles;
     let allFilesClean = allFiles;
-    if (input["include-gitignore"] === true) {
+    if (input.includeGitignore === true) {
         allFilesClean = allFiles.filter((file) => !gitIgnoreFiles.includes(file));
         filesCovered = filesCovered.filter((file) => !gitIgnoreFiles.includes(file));
+    }
+    if (unownedFiles.length) {
+        allFilesClean = allFilesClean.filter((file) => !unownedFiles.includes(file));
+        filesCovered = filesCovered.filter((file) => !unownedFiles.includes(file));
     }
     if (input.files) {
         filesCovered = filesCovered.filter((file) => allFilesClean.includes(file));
@@ -12092,7 +12126,7 @@ const runAction = (_octokit, input) => __awaiter(void 0, void 0, void 0, functio
         });
     }
     if (filesNotCovered.length > 0) {
-        core.setFailed("Files not covered by CODEOWNERS: \n" + filesNotCovered.join("\n"));
+        core.setFailed(`${filesNotCovered.length} files not covered by CODEOWNERS`);
     }
 });
 exports.runAction = runAction;

--- a/dist/index.js
+++ b/dist/index.js
@@ -12007,106 +12007,92 @@ const glob = __importStar(__nccwpck_require__(8090));
 const fs_1 = __nccwpck_require__(7147);
 function getInputs() {
     const result = {};
-    result.token = core.getInput('github-token');
-    result['include-gitignore'] = core.getBooleanInput('include-gitignore');
-    result['ignore-default'] = core.getBooleanInput('ignore-default');
-    result.files = core.getInput('files');
+    result.token = core.getInput("github-token");
+    result["include-gitignore"] = core.getBooleanInput("include-gitignore");
+    result["ignore-default"] = core.getBooleanInput("ignore-default");
+    result.files = core.getInput("files");
     return result;
 }
 exports.getInputs = getInputs;
-const runAction = (octokit, input) => __awaiter(void 0, void 0, void 0, function* () {
-    var _a;
+const runAction = (_octokit, input) => __awaiter(void 0, void 0, void 0, function* () {
     let allFiles = [];
     if (input.files) {
-        allFiles = input.files.split(' ');
-        allFiles = yield (yield glob.create(allFiles.join('\n'))).glob();
+        allFiles = input.files.split(" ");
+        allFiles = yield (yield glob.create(allFiles.join("\n"))).glob();
     }
     else {
-        allFiles = yield (yield glob.create('*')).glob();
+        allFiles = yield (yield glob.create("*")).glob();
     }
     core.startGroup(`All Files: ${allFiles.length}`);
     core.info(JSON.stringify(allFiles));
     core.endGroup();
     let codeownersBuffer;
     try {
-        codeownersBuffer = (0, fs_1.readFileSync)('CODEOWNERS', 'utf8');
+        codeownersBuffer = (0, fs_1.readFileSync)("CODEOWNERS", "utf8");
     }
     catch (error) {
         try {
-            codeownersBuffer = (0, fs_1.readFileSync)('.github/CODEOWNERS', 'utf8');
+            codeownersBuffer = (0, fs_1.readFileSync)(".github/CODEOWNERS", "utf8");
         }
         catch (error) {
-            throw new Error('No CODEOWNERS file found');
+            throw new Error("No CODEOWNERS file found");
         }
     }
-    core.startGroup('CODEOWNERS File');
+    core.startGroup("CODEOWNERS File");
     core.info(codeownersBuffer);
     core.endGroup();
-    let codeownersBufferFiles = codeownersBuffer.split('\n').map(line => line.split(' ')[0]);
-    codeownersBufferFiles = codeownersBufferFiles.filter(file => !file.startsWith('#'));
-    codeownersBufferFiles = codeownersBufferFiles.map(file => file.replace(/^\//, ''));
-    if (input['ignore-default'] === true) {
-        codeownersBufferFiles = codeownersBufferFiles.filter(file => file !== '*');
+    let codeownersBufferFiles = codeownersBuffer
+        .split("\n")
+        .map((line) => line.split(" ")[0]);
+    codeownersBufferFiles = codeownersBufferFiles.filter((file) => !file.startsWith("#"));
+    codeownersBufferFiles = codeownersBufferFiles.map((file) => file.replace(/^\//, ""));
+    if (input["ignore-default"] === true) {
+        codeownersBufferFiles = codeownersBufferFiles.filter((file) => file !== "*");
     }
-    const codeownersGlob = yield glob.create(codeownersBufferFiles.join('\n'));
+    const codeownersGlob = yield glob.create(codeownersBufferFiles.join("\n"));
     let codeownersFiles = yield codeownersGlob.glob();
     core.startGroup(`CODEOWNERS Files: ${codeownersFiles.length}`);
     core.info(JSON.stringify(codeownersFiles));
     core.endGroup();
-    codeownersFiles = codeownersFiles.filter(file => allFiles.includes(file));
+    codeownersFiles = codeownersFiles.filter((file) => allFiles.includes(file));
     core.info(`CODEOWNER Files in All Files: ${codeownersFiles.length}`);
-    core.startGroup('CODEOWNERS');
+    core.startGroup("CODEOWNERS");
     core.info(JSON.stringify(codeownersFiles));
     core.endGroup();
     let gitIgnoreFiles = [];
     try {
-        const gitIgnoreBuffer = (0, fs_1.readFileSync)('.gitignore', 'utf8');
+        const gitIgnoreBuffer = (0, fs_1.readFileSync)(".gitignore", "utf8");
         const gitIgnoreGlob = yield glob.create(gitIgnoreBuffer);
         gitIgnoreFiles = yield gitIgnoreGlob.glob();
         core.info(`.gitignore Files: ${gitIgnoreFiles.length}`);
     }
     catch (error) {
-        core.info('No .gitignore file found');
+        core.info("No .gitignore file found");
     }
     let filesCovered = codeownersFiles;
     let allFilesClean = allFiles;
-    if (input['include-gitignore'] === true) {
-        allFilesClean = allFiles.filter(file => !gitIgnoreFiles.includes(file));
-        filesCovered = filesCovered.filter(file => !gitIgnoreFiles.includes(file));
+    if (input["include-gitignore"] === true) {
+        allFilesClean = allFiles.filter((file) => !gitIgnoreFiles.includes(file));
+        filesCovered = filesCovered.filter((file) => !gitIgnoreFiles.includes(file));
     }
     if (input.files) {
-        filesCovered = filesCovered.filter(file => allFilesClean.includes(file));
+        filesCovered = filesCovered.filter((file) => allFilesClean.includes(file));
     }
     const coveragePercent = (filesCovered.length / allFilesClean.length) * 100;
     const coverageMessage = `${filesCovered.length}/${allFilesClean.length}(${coveragePercent.toFixed(2)}%) files covered by CODEOWNERS`;
     core.notice(coverageMessage, {
-        title: 'Coverage',
-        file: 'CODEOWNERS'
+        title: "Coverage",
+        file: "CODEOWNERS",
     });
-    const filesNotCovered = allFilesClean.filter(f => !filesCovered.includes(f));
-    core.info(`Files not covered: ${filesNotCovered.length}`);
-    if (github.context.eventName === 'pull_request') {
-        const checkResponse = yield octokit.rest.checks.create({
-            owner: github.context.repo.owner,
-            repo: github.context.repo.repo,
-            name: 'Changed Files have CODEOWNERS',
-            head_sha: ((_a = github.context.payload.pull_request) === null || _a === void 0 ? void 0 : _a.head.sha) || github.context.payload.after || github.context.sha,
-            status: 'completed',
-            completed_at: new Date(),
-            output: {
-                title: 'PR Next Version publish successful!',
-                summary: `A version for pull request is **published**. version: **${process.env.CURRENT_VERSION}**`,
-                annotations: filesNotCovered.map(file => ({
-                    path: file,
-                    annotation_level: 'failure',
-                    message: 'File not covered by CODEOWNERS',
-                    start_line: 0,
-                    end_line: 1,
-                })).slice(0, 50),
-            },
-            conclusion: coveragePercent < 100 ? 'failure' : 'success',
+    const filesNotCovered = allFilesClean.filter((f) => !filesCovered.includes(f));
+    for (const file of filesNotCovered) {
+        core.error("File not covered by CODEOWNERS: " + file, {
+            title: "CODEOWNERS coverage",
+            file,
         });
-        console.log('Check Response OK: ', checkResponse.status);
+    }
+    if (filesNotCovered.length > 0) {
+        core.setFailed("Files not covered by CODEOWNERS: \n" + filesNotCovered.join("\n"));
     }
 });
 exports.runAction = runAction;

--- a/dist/index.js
+++ b/dist/index.js
@@ -12116,7 +12116,6 @@ const runAction = (_octokit, input) => __awaiter(void 0, void 0, void 0, functio
     const coverageMessage = `${filesCovered.length}/${allFilesClean.length}(${coveragePercent.toFixed(2)}%) files covered by CODEOWNERS`;
     core.notice(coverageMessage, {
         title: "Coverage",
-        file: "CODEOWNERS",
     });
     const filesNotCovered = allFilesClean.filter((f) => !filesCovered.includes(f));
     for (const file of filesNotCovered) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -5897,7 +5897,7 @@ function expand(str, isTop) {
   var isOptions = m.body.indexOf(',') >= 0;
   if (!isSequence && !isOptions) {
     // {a},b}
-    if (m.post.match(/,.*\}/)) {
+    if (m.post.match(/,(?!,).*\}/)) {
       str = m.pre + '{' + m.body + escClose + m.post;
       return expand(str);
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -12057,17 +12057,25 @@ const runAction = (_octokit, input) => __awaiter(void 0, void 0, void 0, functio
     let codeownersBufferFiles = codeownersBuffer
         .split("\n")
         .map((line) => line.split(" ")[0]);
-    codeownersBufferFiles = codeownersBufferFiles.map((file) => file.replace(/^\//, ""));
     codeownersBufferFiles = codeownersBufferFiles.filter((file) => !file.startsWith("#"));
+    codeownersBufferFiles = codeownersBufferFiles.filter((file) => file !== "");
     if (input.ignoreDefault === true) {
         codeownersBufferFiles = codeownersBufferFiles.filter((file) => file !== "*");
     }
+    codeownersBufferFiles = codeownersBufferFiles.map((file) => codeownerPatternToGlob(file));
+    core.startGroup("CODEOWNERS Glob Patterns");
+    core.info(JSON.stringify(codeownersBufferFiles));
+    core.endGroup();
     const unownedFilesPatterns = input.parseUnownedFiles
         ? codeownersBuffer
             .split("\n")
             .filter((file) => file.startsWith("#?"))
             .map((file) => file.replace(/^#\?\s*/, ""))
+            .map((file) => codeownerPatternToGlob(file))
         : [];
+    core.startGroup(`Unowned Files Glob Patterns: ${unownedFilesPatterns.length}`);
+    core.info(JSON.stringify(unownedFilesPatterns));
+    core.endGroup();
     const codeownersGlob = yield glob.create(codeownersBufferFiles.join("\n"), {
         matchDirectories: false,
     });
@@ -12097,7 +12105,9 @@ const runAction = (_octokit, input) => __awaiter(void 0, void 0, void 0, functio
     });
     const unownedFiles = yield unownedFilesGlob.glob();
     if (input.parseUnownedFiles) {
-        core.info(`Unowned Files: ${unownedFiles.length}`);
+        core.startGroup("`Unowned Files: ${unownedFiles.length}`");
+        core.info(JSON.stringify(unownedFiles));
+        core.endGroup();
     }
     let filesCovered = codeownersFiles;
     let allFilesClean = allFiles;
@@ -12129,6 +12139,14 @@ const runAction = (_octokit, input) => __awaiter(void 0, void 0, void 0, functio
     }
 });
 exports.runAction = runAction;
+function codeownerPatternToGlob(pattern) {
+    if (pattern.startsWith("/")) {
+        return pattern.replace(/^\//, "");
+    }
+    else {
+        return "**/" + pattern;
+    }
+}
 const run = () => __awaiter(void 0, void 0, void 0, function* () {
     try {
         const input = getInputs();

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,12 +76,15 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.28.6.tgz",
+      "integrity": "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.18.6"
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -133,40 +136,41 @@
       "dev": true
     },
     "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.20.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.4.tgz",
-      "integrity": "sha512-luCf7yk/cm7yab6CAW1aiFnmEfBJplb/JojV56MYEK7ziWfGmFlTfmL9Ehwfy4gFhbjBfWO1wj7/TuSbVNEEtA==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.6.tgz",
+      "integrity": "sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.20.2",
-        "@jridgewell/gen-mapping": "^0.3.2",
-        "jsesc": "^2.5.1"
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/generator/node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jridgewell/set-array": "^1.0.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      },
-      "engines": {
-        "node": ">=6.0.0"
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
@@ -188,10 +192,11 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -205,27 +210,12 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-function-name": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
-      "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
       "dev": true,
-      "dependencies": {
-        "@babel/template": "^7.18.10",
-        "@babel/types": "^7.19.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
-      "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.18.6"
-      },
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -295,19 +285,21 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.19.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz",
-      "integrity": "sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -322,109 +314,28 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.1.tgz",
-      "integrity": "sha512-J77mUVaDTUJFZ5BpP6mMn6OIl3rEWymk2ZxDBQJUG3P+PbmyMcF3bYWvz0ma69Af1oobDqT/iAsvzhB58xhQUg==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
+      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.20.1",
-        "@babel/types": "^7.20.0"
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.18.6",
-        "chalk": "^2.0.0",
-        "js-tokens": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
-    },
-    "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.20.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.3.tgz",
-      "integrity": "sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.6.tgz",
+      "integrity": "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.6"
+      },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -610,58 +521,48 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
-      "integrity": "sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.18.6",
-        "@babel/parser": "^7.18.10",
-        "@babel/types": "^7.18.10"
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.1.tgz",
-      "integrity": "sha512-d3tN8fkVJwFLkHkBN479SOsw4DMZnz8cdbL/gvuDuzy3TS6Nfw80HuQqhw1pITbIruHyh7d1fMA47kWzmcUEGA==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.6.tgz",
+      "integrity": "sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.20.1",
-        "@babel/helper-environment-visitor": "^7.18.9",
-        "@babel/helper-function-name": "^7.19.0",
-        "@babel/helper-hoist-variables": "^7.18.6",
-        "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.20.1",
-        "@babel/types": "^7.20.0",
-        "debug": "^4.1.0",
-        "globals": "^11.1.0"
+        "@babel/code-frame": "^7.28.6",
+        "@babel/generator": "^7.28.6",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.28.6",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.28.6",
+        "debug": "^4.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/traverse/node_modules/globals": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@babel/types": {
-      "version": "7.20.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.2.tgz",
-      "integrity": "sha512-FnnvsNWgZCr232sqtXggapvlkk/tuwR/qhGzcmxI0GXLCjmPYQPzio2FbdlWuY6y1sHFfQKk+rRbUZ9VStQMog==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.6.tgz",
+      "integrity": "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.19.4",
-        "@babel/helper-validator-identifier": "^7.19.1",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -790,10 +691,11 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -1169,19 +1071,21 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-      "dev": true
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.17",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
-      "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jridgewell/resolve-uri": "3.1.0",
-        "@jridgewell/sourcemap-codec": "1.4.14"
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1937,21 +1841,23 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -2191,10 +2097,11 @@
       "dev": true
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -2703,10 +2610,11 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -3072,6 +2980,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -3137,10 +3046,11 @@
       }
     },
     "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -3754,13 +3664,15 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -3769,15 +3681,16 @@
       }
     },
     "node_modules/jsesc": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=6"
       }
     },
     "node_modules/json-parse-even-better-errors": {
@@ -3799,10 +3712,11 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -3874,18 +3788,6 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -3902,10 +3804,11 @@
       }
     },
     "node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -3941,12 +3844,13 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -4216,10 +4120,11 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -4527,13 +4432,11 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4748,20 +4651,12 @@
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
     },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -5133,10 +5028,11 @@
       }
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5193,12 +5089,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
     },
     "node_modules/yargs": {
       "version": "17.6.2",

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,31 +1,34 @@
-import * as core from '@actions/core';
-import * as github from '@actions/github';
+import * as core from "@actions/core";
+import * as github from "@actions/github";
 import * as glob from "@actions/glob";
-import { readFileSync } from 'fs';
+import { readFileSync } from "fs";
 
 interface Input {
   token: string;
-  'include-gitignore': boolean;
-  'ignore-default': boolean;
+  "include-gitignore": boolean;
+  "ignore-default": boolean;
   files: string;
 }
 
 export function getInputs(): Input {
   const result = {} as Input;
-  result.token = core.getInput('github-token');
-  result['include-gitignore'] = core.getBooleanInput('include-gitignore');
-  result['ignore-default'] = core.getBooleanInput('ignore-default');
-  result.files = core.getInput('files');
+  result.token = core.getInput("github-token");
+  result["include-gitignore"] = core.getBooleanInput("include-gitignore");
+  result["ignore-default"] = core.getBooleanInput("ignore-default");
+  result.files = core.getInput("files");
   return result;
 }
 
-export const runAction = async (octokit: ReturnType<typeof github.getOctokit>, input: Input): Promise<void> => {
+export const runAction = async (
+  octokit: ReturnType<typeof github.getOctokit>,
+  input: Input
+): Promise<void> => {
   let allFiles: string[] = [];
   if (input.files) {
-    allFiles = input.files.split(' ');
-    allFiles = await (await glob.create(allFiles.join('\n'))).glob();
+    allFiles = input.files.split(" ");
+    allFiles = await (await glob.create(allFiles.join("\n"))).glob();
   } else {
-    allFiles = await (await glob.create('*')).glob();
+    allFiles = await (await glob.create("*")).glob();
   }
   core.startGroup(`All Files: ${allFiles.length}`);
   core.info(JSON.stringify(allFiles));
@@ -33,95 +36,118 @@ export const runAction = async (octokit: ReturnType<typeof github.getOctokit>, i
 
   let codeownersBuffer: string;
   try {
-    codeownersBuffer = readFileSync('CODEOWNERS', 'utf8');
+    codeownersBuffer = readFileSync("CODEOWNERS", "utf8");
   } catch (error) {
     try {
-      codeownersBuffer = readFileSync('.github/CODEOWNERS', 'utf8');
+      codeownersBuffer = readFileSync(".github/CODEOWNERS", "utf8");
     } catch (error) {
-      throw new Error('No CODEOWNERS file found');
+      throw new Error("No CODEOWNERS file found");
     }
   }
-  core.startGroup('CODEOWNERS File');
+  core.startGroup("CODEOWNERS File");
   core.info(codeownersBuffer);
   core.endGroup();
-  let codeownersBufferFiles = codeownersBuffer.split('\n').map(line => line.split(' ')[0]);
-  codeownersBufferFiles = codeownersBufferFiles.filter(file => !file.startsWith('#'));
-  codeownersBufferFiles = codeownersBufferFiles.map(file => file.replace(/^\//, ''));
-  if (input['ignore-default'] === true) {
-    codeownersBufferFiles = codeownersBufferFiles.filter(file => file !== '*');
+  let codeownersBufferFiles = codeownersBuffer
+    .split("\n")
+    .map((line) => line.split(" ")[0]);
+  codeownersBufferFiles = codeownersBufferFiles.filter(
+    (file) => !file.startsWith("#")
+  );
+  codeownersBufferFiles = codeownersBufferFiles.map((file) =>
+    file.replace(/^\//, "")
+  );
+  if (input["ignore-default"] === true) {
+    codeownersBufferFiles = codeownersBufferFiles.filter(
+      (file) => file !== "*"
+    );
   }
-  const codeownersGlob = await glob.create(codeownersBufferFiles.join('\n'));
+  const codeownersGlob = await glob.create(codeownersBufferFiles.join("\n"));
   let codeownersFiles = await codeownersGlob.glob();
   core.startGroup(`CODEOWNERS Files: ${codeownersFiles.length}`);
   core.info(JSON.stringify(codeownersFiles));
   core.endGroup();
-  codeownersFiles = codeownersFiles.filter(file => allFiles.includes(file));
+  codeownersFiles = codeownersFiles.filter((file) => allFiles.includes(file));
   core.info(`CODEOWNER Files in All Files: ${codeownersFiles.length}`);
-  core.startGroup('CODEOWNERS');
+  core.startGroup("CODEOWNERS");
   core.info(JSON.stringify(codeownersFiles));
   core.endGroup();
 
   let gitIgnoreFiles: string[] = [];
   try {
-    const gitIgnoreBuffer = readFileSync('.gitignore', 'utf8');
+    const gitIgnoreBuffer = readFileSync(".gitignore", "utf8");
     const gitIgnoreGlob = await glob.create(gitIgnoreBuffer);
     gitIgnoreFiles = await gitIgnoreGlob.glob();
     core.info(`.gitignore Files: ${gitIgnoreFiles.length}`);
   } catch (error) {
-    core.info('No .gitignore file found');
+    core.info("No .gitignore file found");
   }
 
   let filesCovered = codeownersFiles;
   let allFilesClean = allFiles;
-  if (input['include-gitignore'] === true) {
-    allFilesClean = allFiles.filter(file => !gitIgnoreFiles.includes(file));
-    filesCovered = filesCovered.filter(file => !gitIgnoreFiles.includes(file));
+  if (input["include-gitignore"] === true) {
+    allFilesClean = allFiles.filter((file) => !gitIgnoreFiles.includes(file));
+    filesCovered = filesCovered.filter(
+      (file) => !gitIgnoreFiles.includes(file)
+    );
   }
   if (input.files) {
-    filesCovered = filesCovered.filter(file => allFilesClean.includes(file));
+    filesCovered = filesCovered.filter((file) => allFilesClean.includes(file));
   }
   const coveragePercent = (filesCovered.length / allFilesClean.length) * 100;
-  const coverageMessage = `${filesCovered.length}/${allFilesClean.length}(${coveragePercent.toFixed(2)}%) files covered by CODEOWNERS`;
+  const coverageMessage = `${filesCovered.length}/${
+    allFilesClean.length
+  }(${coveragePercent.toFixed(2)}%) files covered by CODEOWNERS`;
   core.notice(coverageMessage, {
-    title: 'Coverage',
-    file: 'CODEOWNERS'
+    title: "Coverage",
+    file: "CODEOWNERS",
   });
 
-  const filesNotCovered = allFilesClean.filter(f => !filesCovered.includes(f));
+  const filesNotCovered = allFilesClean.filter(
+    (f) => !filesCovered.includes(f)
+  );
   core.info(`Files not covered: ${filesNotCovered.length}`);
 
-  if (github.context.eventName === 'pull_request') {
+  if (github.context.eventName === "pull_request") {
     const checkResponse = await octokit.rest.checks.create({
       owner: github.context.repo.owner,
       repo: github.context.repo.repo,
-      name: 'Changed Files have CODEOWNERS',
-      head_sha: github.context.payload.pull_request?.head.sha || github.context.payload.after || github.context.sha,
-      status: 'completed',
+      name: "Changed Files have CODEOWNERS",
+      head_sha:
+        github.context.payload.pull_request?.head.sha ||
+        github.context.payload.after ||
+        github.context.sha,
+      status: "completed",
       completed_at: new Date(),
       output: {
-        title: 'PR Next Version publish successful!',
+        title: "PR Next Version publish successful!",
         summary: `A version for pull request is **published**. version: **${process.env.CURRENT_VERSION}**`,
-        annotations: filesNotCovered.map(file => ({
-          path: file,
-          annotation_level: 'failure',
-          message: 'File not covered by CODEOWNERS',
-          start_line: 0,
-          end_line: 1,
-        })).slice(0, 50),
+        annotations: filesNotCovered
+          .map((file) => ({
+            path: file,
+            annotation_level: "failure",
+            message: "File not covered by CODEOWNERS",
+            start_line: 0,
+            end_line: 1,
+          }))
+          .slice(0, 50),
       },
-      conclusion: coveragePercent < 100 ? 'failure' : 'success',
+      conclusion: coveragePercent < 100 ? "failure" : "success",
     });
-    console.log('Check Response OK: ', checkResponse.status);
+    console.log("Check Response OK: ", checkResponse.status);
   }
-}
+};
 
 const run = async (): Promise<void> => {
   try {
     const input = getInputs();
-    const octokit: ReturnType<typeof github.getOctokit> = github.getOctokit(input.token);
+    const octokit: ReturnType<typeof github.getOctokit> = github.getOctokit(
+      input.token
+    );
     return runAction(octokit, input);
   } catch (error) {
-    core.startGroup(error instanceof Error ? error.message : JSON.stringify(error));
+    core.startGroup(
+      error instanceof Error ? error.message : JSON.stringify(error)
+    );
     core.info(JSON.stringify(error, null, 2));
     core.endGroup();
   }

--- a/src/run.ts
+++ b/src/run.ts
@@ -20,7 +20,7 @@ export function getInputs(): Input {
 }
 
 export const runAction = async (
-  octokit: ReturnType<typeof github.getOctokit>,
+  _octokit: ReturnType<typeof github.getOctokit>,
   input: Input
 ): Promise<void> => {
   let allFiles: string[] = [];
@@ -105,35 +105,18 @@ export const runAction = async (
   const filesNotCovered = allFilesClean.filter(
     (f) => !filesCovered.includes(f)
   );
-  core.info(`Files not covered: ${filesNotCovered.length}`);
 
-  if (github.context.eventName === "pull_request") {
-    const checkResponse = await octokit.rest.checks.create({
-      owner: github.context.repo.owner,
-      repo: github.context.repo.repo,
-      name: "Changed Files have CODEOWNERS",
-      head_sha:
-        github.context.payload.pull_request?.head.sha ||
-        github.context.payload.after ||
-        github.context.sha,
-      status: "completed",
-      completed_at: new Date(),
-      output: {
-        title: "PR Next Version publish successful!",
-        summary: `A version for pull request is **published**. version: **${process.env.CURRENT_VERSION}**`,
-        annotations: filesNotCovered
-          .map((file) => ({
-            path: file,
-            annotation_level: "failure",
-            message: "File not covered by CODEOWNERS",
-            start_line: 0,
-            end_line: 1,
-          }))
-          .slice(0, 50),
-      },
-      conclusion: coveragePercent < 100 ? "failure" : "success",
+  for (const file of filesNotCovered) {
+    core.error("File not covered by CODEOWNERS: " + file, {
+      title: "CODEOWNERS coverage",
+      file,
     });
-    console.log("Check Response OK: ", checkResponse.status);
+  }
+
+  if (filesNotCovered.length > 0) {
+    core.setFailed(
+      "Files not covered by CODEOWNERS: \n" + filesNotCovered.join("\n")
+    );
   }
 };
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -145,7 +145,6 @@ export const runAction = async (
   }(${coveragePercent.toFixed(2)}%) files covered by CODEOWNERS`;
   core.notice(coverageMessage, {
     title: "Coverage",
-    file: "CODEOWNERS",
   });
 
   const filesNotCovered = allFilesClean.filter(

--- a/src/run.ts
+++ b/src/run.ts
@@ -70,24 +70,35 @@ export const runAction = async (
   let codeownersBufferFiles = codeownersBuffer
     .split("\n")
     .map((line) => line.split(" ")[0]);
-  codeownersBufferFiles = codeownersBufferFiles.map((file) =>
-    file.replace(/^\//, "")
-  );
   codeownersBufferFiles = codeownersBufferFiles.filter(
     (file) => !file.startsWith("#")
   );
+  codeownersBufferFiles = codeownersBufferFiles.filter((file) => file !== "");
   if (input.ignoreDefault === true) {
     codeownersBufferFiles = codeownersBufferFiles.filter(
       (file) => file !== "*"
     );
   }
+  codeownersBufferFiles = codeownersBufferFiles.map((file) =>
+    codeownerPatternToGlob(file)
+  );
+
+  core.startGroup("CODEOWNERS Glob Patterns");
+  core.info(JSON.stringify(codeownersBufferFiles));
+  core.endGroup();
 
   const unownedFilesPatterns: string[] = input.parseUnownedFiles
     ? codeownersBuffer
         .split("\n")
         .filter((file) => file.startsWith("#?"))
         .map((file) => file.replace(/^#\?\s*/, ""))
+        .map((file) => codeownerPatternToGlob(file))
     : [];
+  core.startGroup(
+    `Unowned Files Glob Patterns: ${unownedFilesPatterns.length}`
+  );
+  core.info(JSON.stringify(unownedFilesPatterns));
+  core.endGroup();
 
   const codeownersGlob = await glob.create(codeownersBufferFiles.join("\n"), {
     matchDirectories: false,
@@ -119,7 +130,9 @@ export const runAction = async (
   });
   const unownedFiles: string[] = await unownedFilesGlob.glob();
   if (input.parseUnownedFiles) {
-    core.info(`Unowned Files: ${unownedFiles.length}`);
+    core.startGroup("`Unowned Files: ${unownedFiles.length}`");
+    core.info(JSON.stringify(unownedFiles));
+    core.endGroup();
   }
 
   let filesCovered = codeownersFiles;
@@ -162,6 +175,25 @@ export const runAction = async (
     core.setFailed(`${filesNotCovered.length} files not covered by CODEOWNERS`);
   }
 };
+
+function codeownerPatternToGlob(pattern: string): string {
+  // CODEOWNERS patterns are kind of like gitignore. By default
+  // they match in any directory, unless they start with `/`, in
+  // which case they start from the workspace root.
+  // Ex. `index.js` would match any `index.js` file anywhere in the project,
+  // but `/package.json` would specifically match the root `package.json` file
+  // and not any others.
+
+  // Glob patterns are relative to the workspace root by default,
+  // but a prefix of `**/` creates behavior similar to no prefix in CODEOWNERS.
+
+  // TODO: document the differences between syntaxes
+  if (pattern.startsWith("/")) {
+    return pattern.replace(/^\//, "");
+  } else {
+    return "**/" + pattern;
+  }
+}
 
 const run = async (): Promise<void> => {
   try {


### PR DESCRIPTION
- **Update README.md**
- **Format with Prettier**
- **Replace the weird check with something simpler**
- **npm run build**
- **feat: Support a notation for unowned files (#3)**
- **Don't put a notice on CODEOWNERS file (#4)**
- **fix: Match behavior of actual CODEOWNERS files (#5)**
- **npm audit fix (#6)**
- **chore: Update changed-files action to v45.0.8 in workflow**


